### PR TITLE
Adding support for CRLF's

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -27,7 +27,7 @@ func New(r io.Reader) io.Reader {
 func (r reader) Read(p []byte) (n int, err error) {
 	n, err = r.r.Read(p)
 	for i, b := range p {
-		if b == rByte && i < len(p) && p[i+1] != nByte {
+		if j := i + 1; b == rByte && ((j < len(p) && p[j] != nByte) || j == len(p)) {
 			p[i] = nByte
 		}
 	}

--- a/reader.go
+++ b/reader.go
@@ -27,7 +27,7 @@ func New(r io.Reader) io.Reader {
 func (r reader) Read(p []byte) (n int, err error) {
 	n, err = r.r.Read(p)
 	for i, b := range p {
-		if b == rByte {
+		if b == rByte && i < len(p) && p[i+1] != nByte {
 			p[i] = nByte
 		}
 	}

--- a/reader_test.go
+++ b/reader_test.go
@@ -46,7 +46,7 @@ func TestCR(t *testing.T) {
 		t.Errorf("An error occurred while reading the data: %v", err)
 	}
 	if len(lines) != 2 {
-		t.Error("Wrong number of lines. Expected 2, got %d", len(lines))
+		t.Errorf("Wrong number of lines. Expected 2, got %d", len(lines))
 	}
 }
 
@@ -60,7 +60,7 @@ func TestLF(t *testing.T) {
 		t.Errorf("An error occurred while reading the data: %v", err)
 	}
 	if len(lines) != 2 {
-		t.Error("Wrong number of lines. Expected 2, got %d", len(lines))
+		t.Errorf("Wrong number of lines. Expected 2, got %d", len(lines))
 	}
 }
 
@@ -74,7 +74,7 @@ func TestCRLF(t *testing.T) {
 		t.Errorf("An error occurred while reading the data: %v", err)
 	}
 	if len(lines) != 2 {
-		t.Error("Wrong number of lines. Expected 2, got %d", len(lines))
+		t.Errorf("Wrong number of lines. Expected 2, got %d", len(lines))
 	}
 }
 
@@ -88,7 +88,7 @@ func TestCRInQuote(t *testing.T) {
 		t.Errorf("An error occurred while reading the data: %v", err)
 	}
 	if len(lines) != 2 {
-		t.Error("Wrong number of lines. Expected 2, got %d", len(lines))
+		t.Errorf("Wrong number of lines. Expected 2, got %d", len(lines))
 	}
 	if strings.Contains(lines[1][1], "\n\n") {
 		t.Error("The CRLF was converted to a LFLF")

--- a/reader_test.go
+++ b/reader_test.go
@@ -1,6 +1,7 @@
 package macreader
 
 import (
+	"testing"
 	"bytes"
 	"encoding/csv"
 	"fmt"
@@ -31,4 +32,61 @@ func Example() {
 	// Output: Without macreader: [][]string{[]string{"a", "b", "c\r1", "2", "3"}}
 	// With macreader: [][]string{[]string{"a", "b", "c"}, []string{"1", "2", "3"}}
 
+}
+
+
+func TestCR(t *testing.T) {
+	testFile := bytes.NewBufferString("a,b,c\r1,2,3\r").Bytes()
+
+	r := csv.NewReader(New(bytes.NewReader(testFile)))
+	lines, err := r.ReadAll()
+
+	if err != nil {
+		t.Errorf("An error occurred while reading the data: %v", err)
+	}
+	if len(lines) != 2 {
+		t.Error("Wrong number of lines. Expected 2, got %d", len(lines))
+	}
+}
+
+func TestLF(t *testing.T) {
+	testFile := bytes.NewBufferString("a,b,c\n1,2,3\n").Bytes()
+
+	r := csv.NewReader(New(bytes.NewReader(testFile)))
+	lines, err := r.ReadAll()
+
+	if err != nil {
+		t.Errorf("An error occurred while reading the data: %v", err)
+	}
+	if len(lines) != 2 {
+		t.Error("Wrong number of lines. Expected 2, got %d", len(lines))
+	}
+}
+
+func TestCRLF(t *testing.T) {
+	testFile := bytes.NewBufferString("a,b,c\r\n1,2,3\r\n").Bytes()
+
+	r := csv.NewReader(New(bytes.NewReader(testFile)))
+	lines, err := r.ReadAll()
+
+	if err != nil {
+		t.Errorf("An error occurred while reading the data: %v", err)
+	}
+	if len(lines) != 2 {
+		t.Error("Wrong number of lines. Expected 2, got %d", len(lines))
+	}
+}
+
+func TestCRInQuote(t *testing.T) {
+	testFile := bytes.NewBufferString("a,\"foo,\rbar\",c\r1,\"2\r\n2\",3\r").Bytes()
+
+	r := csv.NewReader(New(bytes.NewReader(testFile)))
+	lines, err := r.ReadAll()
+
+	if err != nil {
+		t.Errorf("An error occurred while reading the data: %v", err)
+	}
+	if len(lines) != 2 {
+		t.Error("Wrong number of lines. Expected 2, got %d", len(lines))
+	}
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/csv"
 	"fmt"
+	"strings"
 )
 
 func Example() {
@@ -88,5 +89,8 @@ func TestCRInQuote(t *testing.T) {
 	}
 	if len(lines) != 2 {
 		t.Error("Wrong number of lines. Expected 2, got %d", len(lines))
+	}
+	if strings.Contains(lines[1][1], "\n\n") {
+		t.Error("The CRLF was converted to a LFLF")
 	}
 }


### PR DESCRIPTION
In the current code, when a CRLF is encountered the result will be a LFLF. The Go CSV Reader will handle an unquoted LFLF by ignoring the empty line, but if the CRLF occurs inside of a quoted string then the LFLF will be maintained.

This change accounts for that by ignoring a CR that is followed by a LF. The resulting CRLF is properly handled by the CSV Reader which strips the preceding CR: "Carriage returns before newline characters are silently removed." ([source](https://golang.org/pkg/encoding/csv/)).
